### PR TITLE
Adding an outputTemplate optional parameter to NLog sink

### DIFF
--- a/src/Serilog.Sinks.NLog/LoggerConfigurationsNLogExtensions.cs
+++ b/src/Serilog.Sinks.NLog/LoggerConfigurationsNLogExtensions.cs
@@ -16,6 +16,7 @@ using System;
 using Serilog.Sinks.NLog;
 using Serilog.Configuration;
 using Serilog.Events;
+using Serilog.Formatting.Display;
 
 namespace Serilog
 {
@@ -24,6 +25,8 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationsNLogExtensions
     {
+        const string DefaultOutputTemplate = "{Message}";
+
         /// <summary>
         /// Adds a sink that writes adapted log events to NLog.
         /// </summary>
@@ -35,14 +38,17 @@ namespace Serilog
         public static LoggerConfiguration NLog(
             this LoggerSinkConfiguration loggerConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null)
         {
             if (loggerConfiguration == null)
             {
-                throw new ArgumentNullException("loggerConfiguration");
+                throw new ArgumentNullException(nameof(loggerConfiguration));
             }
 
-            return loggerConfiguration.Sink(new NLogSink(formatProvider), restrictedToMinimumLevel);
+            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+
+            return loggerConfiguration.Sink(new NLogSink(formatter), restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.NLog/Sinks/NLog/NLogSink.cs
+++ b/src/Serilog.Sinks.NLog/Sinks/NLog/NLogSink.cs
@@ -3,16 +3,18 @@ using NLog;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
+using Serilog.Formatting;
+using System.IO;
 
 namespace Serilog.Sinks.NLog
 {
     class NLogSink : ILogEventSink
     {
-        readonly IFormatProvider formatProvider;
+        readonly ITextFormatter textFormatter;
 
-        public NLogSink(IFormatProvider formatProvider = null)
+        public NLogSink(ITextFormatter textFormatter)
         {
-            this.formatProvider = formatProvider;
+            this.textFormatter = textFormatter;
         }
 
         public void Emit(LogEvent logEvent)
@@ -30,10 +32,14 @@ namespace Serilog.Sinks.NLog
             }
 
             var level = GetMappedLevel(logEvent);
-            var message = logEvent.RenderMessage(formatProvider);
+
+            var renderSpace = new StringWriter();
+            this.textFormatter.Format(logEvent, renderSpace);
+
+            //var message = logEvent.RenderMessage(formatProvider);
             var exception = logEvent.Exception;
 
-            var nlogEvent = new LogEventInfo(level, loggerName, message)
+            var nlogEvent = new LogEventInfo(level, loggerName, renderSpace.ToString())
             {
                 Exception = exception
             };

--- a/src/Serilog.Sinks.NLog/project.json
+++ b/src/Serilog.Sinks.NLog/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.0.0-*",
+  "version": "4.0.0-*",
   "description": "Serilog event sink that writes to NLog. Merge your new Serilog event stream into your existing NLog infrastructure.",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/test/Serilog.Sinks.NLog.Tests/Serilog.Sinks.NLog.Tests.xproj
+++ b/test/Serilog.Sinks.NLog.Tests/Serilog.Sinks.NLog.Tests.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Serilog.Sinks.NLog.Tests/Sinks/NLog/NLogSinkTest.cs
+++ b/test/Serilog.Sinks.NLog.Tests/Sinks/NLog/NLogSinkTest.cs
@@ -1,0 +1,90 @@
+﻿using NLog;
+using NLog.Config;
+using NLog.Targets;
+using Serilog.Core;
+using System.Linq;
+using Xunit;
+
+namespace Serilog.Sinks.NLog.Tests.Sinks.NLog
+{
+    public class NLogSinkTest
+    {
+        [Fact]
+        public void LogsAreSentToNLog()
+        {
+            // Fixture setup
+            SetupNLogConfiguration();
+            // Exercise system
+            var log = new LoggerConfiguration()
+                .WriteTo.NLog()
+                .CreateLogger();
+            log.Warning("The quick brown fox jumps over the lazy dog");
+            // Verify outcome
+            var result = GetLastLoggedLineFromNLogMemotyTarget();
+            Assert.Equal("Default|Warn|The quick brown fox jumps over the lazy dog", result);
+            // Teardown 
+            TeardownNLogConfiguration();
+        }
+
+        [Fact]
+        public void SourceContextIsUsedForNLogLogName()
+        {
+            // Fixture setup
+            SetupNLogConfiguration();
+            // Exercise system
+            var log = new LoggerConfiguration()
+                .Enrich.WithProperty(Constants.SourceContextPropertyName, "Test")
+                .MinimumLevel.Verbose()
+                .WriteTo.NLog()
+                .CreateLogger();
+            log.Debug("The quick brown fox jumps over the lazy dog");
+            // Verify outcome
+            var result = GetLastLoggedLineFromNLogMemotyTarget();
+            Assert.Equal("Test|Debug|The quick brown fox jumps over the lazy dog", result);
+            // Teardown 
+            TeardownNLogConfiguration();
+        }
+
+        [Fact]
+        public void TestOutputTemplate()
+        {
+            // Fixture setup
+            SetupNLogConfiguration();
+            // Exercise system
+            var log = new LoggerConfiguration()
+                .WriteTo.NLog(outputTemplate: "[{Level}] - {Message}")
+                .CreateLogger();
+            log.Information("The quick brown fox jumps over the lazy dog");
+            // Verify outcome
+            var result = GetLastLoggedLineFromNLogMemotyTarget();
+            Assert.Equal("Default|Info|[Information] - The quick brown fox jumps over the lazy dog", result);
+            // Teardown
+            TeardownNLogConfiguration();
+        }
+
+        private const string MemoryTargetName = "memory";
+        private const string DefaultNLogLayout = @"${logger}|${level}|${message}";
+
+        private void SetupNLogConfiguration()
+        {
+            var config = new LoggingConfiguration();
+            var memoryTarget = new MemoryTarget();
+            config.AddTarget(MemoryTargetName, memoryTarget);
+            memoryTarget.Layout = DefaultNLogLayout;
+            var rule = new LoggingRule("*", LogLevel.Trace, memoryTarget);
+            config.LoggingRules.Add(rule);
+            LogManager.Configuration = config;
+        }
+
+        private void TeardownNLogConfiguration()
+        {
+            LogManager.Configuration = null;
+        }
+
+        private string GetLastLoggedLineFromNLogMemotyTarget()
+        {
+            var target = (MemoryTarget)LogManager.Configuration.FindTargetByName(MemoryTargetName);
+            return target.Logs.Last();
+        }
+    }
+}

--- a/test/Serilog.Sinks.NLog.Tests/project.json
+++ b/test/Serilog.Sinks.NLog.Tests/project.json
@@ -2,7 +2,9 @@
   "testRunner": "xunit",
   "dependencies": {
     "xunit": "2.2.0-beta2-build3300",
+    "xunit.runner.visualstudio": "2.1.0",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "NLog": "4.4.0-betaV15",
     "Serilog.Sinks.NLog": { "target": "project" }
   },
   "frameworks": {


### PR DESCRIPTION
Addresses #3 (I would find this useful on a current project).

I added an optional ```outputTemplate``` parameter to NLog extension method in order to pass a template.
This is a breaking change when it comes to NLogSince since it now expects a ```ITextFormatter ``` instead of a ```IFormatProvider``` (but adding an optional parameter is also a breaking change, binary wise).

This allows the caller to specify a format using Serilog's properties and enrich what is being logged.

I also added a few unit tests to make sure I didn't break the existing behavior.